### PR TITLE
Stop blinking cursor on an inactive window

### DIFF
--- a/a-Shell/SceneDelegate.swift
+++ b/a-Shell/SceneDelegate.swift
@@ -11,6 +11,7 @@ import SwiftUI
 import WebKit
 import ios_system
 import MobileCoreServices
+import Combine
 
 var messageHandlerAdded = false
 var externalKeyboardPresent: Bool? // still needed?
@@ -46,6 +47,8 @@ class SceneDelegate: UIViewController, UIWindowSceneDelegate, WKScriptMessageHan
     // Store these for session restore:
     var currentDirectory = ""
     var previousDirectory = ""
+    // Store cancelalble instances
+    var cancellables = Set<AnyCancellable>()
     
     // Create a document picker for directories.
     private let documentPicker =
@@ -767,6 +770,30 @@ class SceneDelegate: UIViewController, UIWindowSceneDelegate, WKScriptMessageHan
                     }
                 }
             }
+
+            let didBecomeKey = NotificationCenter.default
+                .publisher(for: UIWindow.didBecomeKeyNotification, object: window)
+            let didResignKey = NotificationCenter.default
+                .publisher(for: UIWindow.didResignKeyNotification, object: window)
+            Publishers.Merge(didBecomeKey, didResignKey)
+                .handleEvents(receiveOutput: { notification in
+                    NSLog("\(notification.name.rawValue): \(session.persistentIdentifier).")
+                })
+                .sink { _ in
+                    // TODO: When two windows open side-by-side on launching the app,
+                    // the left window's didResignKeyNotification event is earlier than loading window.term_,
+                    // so it cannot focus out the cursor.
+                    let command = "window.term_.onFocusChange_(\(window.isKeyWindow));"
+                    self.webView?.evaluateJavaScript(command) { result, error in
+                        if let error = error {
+                            print(error)
+                        }
+                        if let result = result {
+                            print(result)
+                        }
+                    }
+                }
+                .store(in: &cancellables)
         }
     }
 


### PR DESCRIPTION
I implemented:

* start blinking the cursor when its window become active
* stop blinking the cursor when its window become inactive

That is on [your to-do list](https://github.com/holzschu/a-shell/projects/1#card-23831768).

However, my implementation has a little issue, that is commented on [the line](https://github.com/holzschu/a-shell/pull/11/files#diff-333a35a9fb3474371ed5f70eadb9572dR783).

> // TODO: When two windows open side-by-side on launching the app,
> // the left window's didResignKeyNotification event is earlier than loading window.term_,
> // so it cannot focus out the cursor.