### PR TITLE
WIP: Fix clear command

### DIFF
--- a/a-Shell/ExtraCommands.swift
+++ b/a-Shell/ExtraCommands.swift
@@ -32,11 +32,13 @@ public func clear(argc: Int32, argv: UnsafeMutablePointer<UnsafeMutablePointer<I
     let opaquePointer = OpaquePointer(ios_getContext())
     guard let stringPointer = UnsafeMutablePointer<CChar>(opaquePointer) else { return 0 }
     let currentSessionIdentifier = String(cString: stringPointer)
-    for scene in UIApplication.shared.connectedScenes {
-        if (scene.session.persistentIdentifier == currentSessionIdentifier) {
-            let delegate: SceneDelegate = scene.delegate as! SceneDelegate
-            delegate.clearScreen()
-            return 0
+    DispatchQueue.main.async {
+        for scene in UIApplication.shared.connectedScenes {
+            if (scene.session.persistentIdentifier == currentSessionIdentifier) {
+                let delegate: SceneDelegate = scene.delegate as! SceneDelegate
+                delegate.clearScreen()
+                return
+            }
         }
     }
     return 0


### PR DESCRIPTION
When I run `clear` command on a-Shell, the following messages are shown on a debug console in Xcode. It seems that `UIApplication.shared.connectedScenes`, `scene.session`, and `scene.delegate` should be called on the main thread.

```
Main Thread Checker: UI API called on a background thread: -[UIApplication connectedScenes]
PID: 2655, TID: 1076413, Thread name: (none), Queue name: com.apple.root.default-qos.overcommit, QoS: 0
Backtrace:
4   a-Shell                             0x00000001029e3c20 $s7a_Shell5clear4argc4argvs5Int32VAF_SpySpys4Int8VGSgGSgtF + 432
5   a-Shell                             0x00000001029e3a68 clear + 12
6   ios_system                          0x0000000102c712b0 run_function + 420
7   libsystem_pthread.dylib             0x0000000184cb3840 _pthread_start + 168
8   libsystem_pthread.dylib             0x0000000184cbb9f4 thread_start + 8
2019-12-14 01:59:33.456932+0900 a-Shell[2655:1076413] [reports] Main Thread Checker: UI API called on a background thread: -[UIApplication connectedScenes]
PID: 2655, TID: 1076413, Thread name: (none), Queue name: com.apple.root.default-qos.overcommit, QoS: 0
Backtrace:
4   a-Shell                             0x00000001029e3c20 $s7a_Shell5clear4argc4argvs5Int32VAF_SpySpys4Int8VGSgGSgtF + 432
5   a-Shell                             0x00000001029e3a68 clear + 12
6   ios_system                          0x0000000102c712b0 run_function + 420
7   libsystem_pthread.dylib             0x0000000184cb3840 _pthread_start + 168
8   libsystem_pthread.dylib             0x0000000184cbb9f4 thread_start + 8
=================================================================
Main Thread Checker: UI API called on a background thread: -[UIScene session]
PID: 2655, TID: 1076413, Thread name: (none), Queue name: com.apple.root.default-qos.overcommit, QoS: 0
Backtrace:
4   a-Shell                             0x00000001029e3cfc $s7a_Shell5clear4argc4argvs5Int32VAF_SpySpys4Int8VGSgGSgtF + 652
5   a-Shell                             0x00000001029e3a68 clear + 12
6   ios_system                          0x0000000102c712b0 run_function + 420
7   libsystem_pthread.dylib             0x0000000184cb3840 _pthread_start + 168
8   libsystem_pthread.dylib             0x0000000184cbb9f4 thread_start + 8
2019-12-14 01:59:44.266417+0900 a-Shell[2655:1076413] [reports] Main Thread Checker: UI API called on a background thread: -[UIScene session]
PID: 2655, TID: 1076413, Thread name: (none), Queue name: com.apple.root.default-qos.overcommit, QoS: 0
Backtrace:
4   a-Shell                             0x00000001029e3cfc $s7a_Shell5clear4argc4argvs5Int32VAF_SpySpys4Int8VGSgGSgtF + 652
5   a-Shell                             0x00000001029e3a68 clear + 12
6   ios_system                          0x0000000102c712b0 run_function + 420
7   libsystem_pthread.dylib             0x0000000184cb3840 _pthread_start + 168
8   libsystem_pthread.dylib             0x0000000184cbb9f4 thread_start + 8
=================================================================
Main Thread Checker: UI API called on a background thread: -[UIScene delegate]
PID: 2655, TID: 1076413, Thread name: (none), Queue name: com.apple.root.default-qos.overcommit, QoS: 0
Backtrace:
4   a-Shell                             0x00000001029e3d90 $s7a_Shell5clear4argc4argvs5Int32VAF_SpySpys4Int8VGSgGSgtF + 800
5   a-Shell                             0x00000001029e3a68 clear + 12
6   ios_system                          0x0000000102c712b0 run_function + 420
7   libsystem_pthread.dylib             0x0000000184cb3840 _pthread_start + 168
8   libsystem_pthread.dylib             0x0000000184cbb9f4 thread_start + 8
2019-12-14 01:59:44.316462+0900 a-Shell[2655:1076216] [Process] kill() returned unexpected error 1
2019-12-14 01:59:44.316309+0900 a-Shell[2655:1076413] [reports] Main Thread Checker: UI API called on a background thread: -[UIScene delegate]
PID: 2655, TID: 1076413, Thread name: (none), Queue name: com.apple.root.default-qos.overcommit, QoS: 0
Backtrace:
4   a-Shell                             0x00000001029e3d90 $s7a_Shell5clear4argc4argvs5Int32VAF_SpySpys4Int8VGSgGSgtF + 800
5   a-Shell                             0x00000001029e3a68 clear + 12
6   ios_system                          0x0000000102c712b0 run_function + 420
7   libsystem_pthread.dylib             0x0000000184cb3840 _pthread_start + 168
8   libsystem_pthread.dylib             0x0000000184cbb9f4 thread_start + 8
```