### PR TITLE
Link ios_system to a-Shell-Intents

### DIFF
--- a/a-Shell.xcodeproj/project.pbxproj
+++ b/a-Shell.xcodeproj/project.pbxproj
@@ -544,6 +544,7 @@
 		22E9F5A2255846F400673D11 /* vim.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 22E9F5A0255846F300673D11 /* vim.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		22E9F5A72558470600673D11 /* bc_ios.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 22E9F5A52558470600673D11 /* bc_ios.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		22F04B4824EFF9B900F9F30A /* pythonA.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 22C9815024CADA4E006C103E /* pythonA.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		89483CE425CC48B2008EF012 /* ios_system.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 228E13F225C95F2D0065D825 /* ios_system.xcframework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -1444,6 +1445,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				89483CE425CC48B2008EF012 /* ios_system.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
relates to https://github.com/holzschu/a-shell/issues/109#issuecomment-773374522

a-Shell-Intents imports ios_system in [this line](https://github.com/holzschu/a-shell/blob/master/a-Shell-Intents/IntentHandler.swift#L10), but now ios_system isn't linked to a-Shell-Intents. I fixed that.

I think @holzschu might forget to add it in [this commit](https://github.com/holzschu/a-shell/commit/50127bdfe9e809ebd05eaa54fb64385c1c374703).