### PR TITLE
Add more keyboard shortcuts

### DIFF
--- a/a-Shell/WKWebView+KeyCommands.swift
+++ b/a-Shell/WKWebView+KeyCommands.swift
@@ -93,8 +93,16 @@ extension WKWebView {
         // clear entire display: ^[[2J
         // position cursor on top line: ^[[1;1H
         // print current command again.
-        let javascriptCommand = "window.term_.io.print('" + escape + "[2J'); window.term_.io.print('" + escape + "[1;1H'); " +
-        " window.printPrompt(); window.term_.io.print(window.term_.io.currentCommand); var endOfCommand = window.term_.io.currentCommand.slice(window.currentCommandCursorPosition, window.term_.io.currentCommand.length); var wcwidth = lib.wc.strWidth(endOfCommand); for (var i = 0; i < wcwidth; i++) { io.print('\\b'); }"
+        let javascriptCommand = #"""
+        window.term_.io.print('\#(escape)[2J\#(escape)[1;1H');
+        window.printPrompt();
+        window.term_.io.print(window.term_.io.currentCommand);
+        var endOfCommand = window.term_.io.currentCommand.slice(window.currentCommandCursorPosition, window.term_.io.currentCommand.length);
+        var wcwidth = lib.wc.strWidth(endOfCommand);
+        for (var i = 0; i < wcwidth; i++) {
+            window.term_.io.print('\b');
+        }
+        """#
         evaluateJavaScript(javascriptCommand) { (result, error) in
             if error != nil {
                // print(error)

--- a/hterm.html
+++ b/hterm.html
@@ -272,6 +272,35 @@
 				}
 			}
 
+			// behaves as if delete key is pressed.
+			function deleteBackward() {
+				if (currentCommandCursorPosition <= 0) {
+					return;
+				}
+
+				const currentChar = window.term_.io.currentCommand[currentCommandCursorPosition - 1];
+				const currentCharWidth = lib.wc.strWidth(currentChar);
+				for (let i = 0; i < currentCharWidth; i++) {
+					window.term_.io.print('\b'); // move cursor back n chars, across lines
+				}
+
+				window.term_.io.print('\x1b[0J'); // delete display after cursor
+
+				// print remainder of command line
+				const endOfCommand = window.term_.io.currentCommand.slice(currentCommandCursorPosition);
+				window.term_.io.print(endOfCommand);
+
+				// move cursor back to where it was (don't use term.screen_.cursorPosition):
+				const wcwidth = lib.wc.strWidth(endOfCommand);
+				for (let i = 0; i < wcwidth; i++) {
+					window.term_.io.print('\b');
+				}
+
+				// remove character from command at current position:
+				window.term_.io.currentCommand = window.term_.io.currentCommand.slice(0, currentCommandCursorPosition - 1) + endOfCommand;
+				currentCommandCursorPosition -= 1;
+			}
+
             function pickCurrentValue() {
 				var currentCommand = window.term_.io.currentCommand;
 				var cursorPosition = window.term_.screen_.cursorPosition.column - window.promptEnd;
@@ -621,28 +650,10 @@
 									break;
 								case String.fromCharCode(127): // delete key from iOS keyboard
 									if (currentCommandCursorPosition > 0) { 
-										var currentChar = io.currentCommand[currentCommandCursorPosition - 1];
-										var currentCharWidth = lib.wc.strWidth(currentChar);
 										if (this.document_.getSelection().type == 'Range') {
 											term.onCut(null); // remove the selection without copying it
 										} else {
-											// clear entire buffer, then reprint. This works even if we are several lines above end of line.
-											for (var i = 0; i < currentCharWidth; i++) {
-												io.print('\b'); // move cursor back n chars
-											}
-											io.print('\x1b[0J'); // delete display after cursor
-											// print remainder of command line
-											var endOfCommand = io.currentCommand.slice(currentCommandCursorPosition, io.currentCommand.length);
-											io.print(endOfCommand)
-											// move cursor back to where it was (don't use term.screen_.cursorPosition):
-											var wcwidth = lib.wc.strWidth(endOfCommand);
-											for (var i = 0; i < wcwidth; i++) {
-												io.print('\b'); 
-											}
-											// remove character from command at current position:
-											io.currentCommand = io.currentCommand.slice(0, currentCommandCursorPosition - 1) + 
-												io.currentCommand.slice(currentCommandCursorPosition, io.currentCommand.length); 
-											currentCommandCursorPosition -= 1;
+											deleteBackward();
 										}
 									}
 									disableAutocompleteMenu();
@@ -933,6 +944,17 @@
 									io.print(io.currentCommand);
 									// move cursor back to beginning of the line
 									io.print(`\x1b[${window.promptMessage.length + 1}G`);
+									break;
+								case String.fromCharCode(23):  // Ctrl+W: kill the word behind point
+									disableAutocompleteMenu();
+									deleteBackward();
+									while (currentCommandCursorPosition > 0) {
+										const currentChar = io.currentCommand[currentCommandCursorPosition - 1];
+										if (!isLetter(currentChar)) {
+											break;
+										}
+										deleteBackward();
+									}
 									break;
 								case String.fromCharCode(12):  // Ctrl-L: clear screen
 									disableAutocompleteMenu();

--- a/hterm.html
+++ b/hterm.html
@@ -215,8 +215,6 @@
 					// let the running command print its own prompt:
 					window.webkit.messageHandlers.aShell.postMessage('input:' + '\n');
 				}
-				window.term_.io.currentCommand = '';
-				currentCommandCursorPosition = 0;
 			}
 
             function updatePromptPosition() {

--- a/hterm.html
+++ b/hterm.html
@@ -652,6 +652,7 @@
 									break;
 								case String.fromCharCode(27) + "[A":  // Up arrow
 								case String.fromCharCode(27) + "[1;3A":  // Alt-Up arrow
+								case String.fromCharCode(16):  // Ctrl+P
 									if (window.commandRunning != '') {
 										if (window.commandInsideCommandIndex > 0) {
 											if (window.commandInsideCommandIndex === window.maxCommandInsideCommandIndex) {
@@ -660,7 +661,7 @@
 											}
 											io.print('\x1b[' + (window.promptLine + 1) + ';' + (window.promptEnd + 1) + 'H'); // move cursor back to initial position
 											io.print('\x1b[0J'); // delete display after cursor
-											if (string == String.fromCharCode(27) + "[A") { 
+											if (string != String.fromCharCode(27) + "[1;3A") {
 												window.commandInsideCommandIndex -= 1;
 												if (window.commandInsideCommandIndex < 0) {
 													window.commandInsideCommandIndex = 0;
@@ -692,7 +693,7 @@
 											var scrolledLines = window.promptScroll - term.scrollPort_.getTopRowIndex();
 											io.print('\x1b[' + (window.promptLine + scrolledLines + 1) + ';' + (window.promptEnd + 1) + 'H'); // move cursor to position at start of line
 											io.print('\x1b[0J'); // delete display after cursor
-											if (string == String.fromCharCode(27) + "[A") { 
+											if (string != String.fromCharCode(27) + "[1;3A") {
 												window.commandIndex -= 1;
 											} else {
 												window.commandIndex -= 5;
@@ -708,11 +709,12 @@
 									break;
 								case String.fromCharCode(27) + "[B":  // Down arrow
 								case String.fromCharCode(27) + "[1;3B":  // Alt-Down arrow
+								case String.fromCharCode(14):  // Ctrl+N
 									if (window.commandRunning != '') {
 										if (window.commandInsideCommandIndex < window.maxCommandInsideCommandIndex) {
 											io.print('\x1b[' + (window.promptLine + 1) + ';' + (window.promptEnd + 1) + 'H'); // move cursor to position at start of line
 											io.print('\x1b[0J'); // delete display after cursor
-											if (string == String.fromCharCode(27) + "[B") { 
+											if (string != String.fromCharCode(27) + "[1;3B") {
 												window.commandInsideCommandIndex += 1;
 											} else {
 												window.commandInsideCommandIndex += 5;
@@ -737,7 +739,7 @@
 											var scrolledLines = window.promptScroll - term.scrollPort_.getTopRowIndex();
 											io.print('\x1b[' + (window.promptLine + scrolledLines + 1) + ';' + (window.promptEnd + 1) + 'H'); // move cursor to position at start of line
 											io.print('\x1b[0J'); // delete display after cursor
-											if (string == String.fromCharCode(27) + "[B") { 
+											if (string != String.fromCharCode(27) + "[1;3B") {
 												window.commandIndex += 1;
 											} else {
 												window.commandIndex += 5;
@@ -752,6 +754,7 @@
 									}
 									break;
 								case String.fromCharCode(27) + "[D":  // Left arrow
+								case String.fromCharCode(2):  // Ctrl+B
 									if (this.document_.getSelection().type == 'Range') {
 										// move cursor to start of selection
 										this.moveCursorPosition(term.scrollPort_.selection.startRow.rowIndex - term.scrollPort_.getTopRowIndex(), term.scrollPort_.selection.startOffset);
@@ -772,6 +775,7 @@
 									}
 									break;
 								case String.fromCharCode(27) + "[C":  // Right arrow
+								case String.fromCharCode(6):  // Ctrl+F
 									if (this.document_.getSelection().type == 'Range') {
 										// move cursor to end of selection
 										this.moveCursorPosition(term.scrollPort_.selection.endRow.rowIndex - term.scrollPort_.getTopRowIndex(), term.scrollPort_.selection.endOffset);

--- a/hterm.html
+++ b/hterm.html
@@ -917,6 +917,19 @@
 										window.term_.io.print('\x1b[0J'); // delete display after cursor
 									}
 									break;
+								case String.fromCharCode(21):  // Ctrl-U: kill from cursor to beginning of the line
+									disableAutocompleteMenu();
+									// clear entire line and move cursor to beginning of the line
+									io.print('\x1b[2K\x1b[G');
+									io.currentCommand = io.currentCommand
+										.slice(currentCommandCursorPosition);
+									currentCommandCursorPosition = 0;
+									// redraw command line
+									printPrompt();
+									io.print(io.currentCommand);
+									// move cursor back to beginning of the line
+									io.print(`\x1b[${window.promptMessage.length + 1}G`);
+									break;
 								case String.fromCharCode(12):  // Ctrl-L: clear screen
 									disableAutocompleteMenu();
 									// erase display, move cursor to (1,1)


### PR DESCRIPTION
closes #171

This PR contains:

1. Add Ctrl+U shortcut for killing backward from the cursor to the beginning of the current line
    - b6918b4dbbd094c8a9e04680852324d37968c0f6
2. Add Ctrl+W shortcut for killing the word behind point, using white space as a word boundary
    - 4f667e18a174e60ff95869ed4d2a6e89e06c2b6f
3. Add Ctrl+P, Ctrl+N, Ctrl+B, and Ctrl+F as alternatives to arrow keys
    - 0a90635262c19ec90a39c1954fe5f7d0f55c65b4
4. Fix the behaviors of Ctrl+L and Cmd+K so that they are the same as ones on bash and sh-compatible shells
    - ae3fc464aa72d12a05cc5201887502dc9558c378 & aa7edca72bda3052f7eb8b8e5576e78d7bee4984

I tested them well, but if you have any concerns, please point them out. I tested on iPad Pro 12.9-inch (3rd gen.) running iPadOS 14.4 with both Smart Keyboard Folio and the on-screen keyboard. For building, I used Xcode 12.4.

References:

- Keyboard shortcuts:
    - [Bash Reference Manual 8.2 Readline Interaction](https://www.gnu.org/software/bash/manual/bash.html#Readline-Interaction)
- Character Codes and Control Sequences:
    - [hterm and Secure Shell - hterm Control Sequences](https://chromium.googlesource.com/apps/libapps/+/HEAD/hterm/doc/ControlSequences.md)