### PR TITLE
Add some requirements to the build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ If you want to compile the project yourself, you will need the following steps:
 * download all the xcFrameworks: `swift run --package-path xcfs` (or `downloadFrameworks.sh`)
 * create the Python xcFrameworks (or remove them from the project, if you don't need Python):
     * You'll need the Xcode command line tools, if you don't already have them: `sudo xcode-select --install` 
-    * You also need the OpenSSL libraries for OS X (libssl and libcrypto) (we provide the versions for iOS and simulator).
+    * You also need the OpenSSL libraries (libssl and libcrypto), XQuartz (freetype), and Node.js (npm) for macOS (we provide the versions for iOS and simulator).
     * change directory to `cpython`: `cd cpython`
     * build Python 3.9 and all the associated libraries / frameworks: `sh ./downloadAndCompile.sh` (this step takes more than 30 mn on a 2GHz i5 MBP, YMMV). 
 * get back to the main directory, open the Xcode project and click "Build", then "Run" as you like.


### PR DESCRIPTION
I found that XQuartz (freetype) and Node.js (npm) were required to build cpython. XQuartz's freetype library is required for Matplotlib and npm is required for Jupyter Notebook. For more details, please see #109.

So, I think it would be better to add them to the build instructions on README.md.