### PR TITLE
`jsi` fix namespace variable re-declaration in build 158

### DIFF
--- a/Resources/bin/jsi
+++ b/Resources/bin/jsi
@@ -749,7 +749,7 @@ def runJS(content, inTermContext=False, recurseDepth=1, sourceFormatter=SourceFo
     toRun += "_jsi.saveFuturePrints();"
 
     outFile = tempfile.NamedTemporaryFile(delete=False)
-    outFile.write(bytes(toRun, "utf-8"))
+    outFile.write(bytes("{ " + toRun + " }", "utf-8"))
     outFile.close()
 
     args = ["jsc"]

--- a/Resources_mini/bin/jsi
+++ b/Resources_mini/bin/jsi
@@ -749,7 +749,7 @@ def runJS(content, inTermContext=False, recurseDepth=1, sourceFormatter=SourceFo
     toRun += "_jsi.saveFuturePrints();"
 
     outFile = tempfile.NamedTemporaryFile(delete=False)
-    outFile.write(bytes(toRun, "utf-8"))
+    outFile.write(bytes("{ " + toRun + " }", "utf-8"))
     outFile.close()
 
     args = ["jsc"]


### PR DESCRIPTION
In build 158, `jsi` currently exits due to its re-definition of println and print. This PR fixes that.