### PR TITLE
`jsi`: Fix escape bug, better HTML formatting

### DIFF
--- a/Resources/bin/jsi
+++ b/Resources/bin/jsi
@@ -168,10 +168,7 @@ _jsi.stringify_obj = function (obj, recurseDepth, indentation, toplevel) {
             result += quoted;
         } else {
             if (obj.search(/[<][\/][a-zA-Z0-9 \t]+[>]/) >= 0 && recurseDepth >= 0) {
-                for (const line of lines) {
-                    outputLine(line);
-                }
-
+                result += termEscape(obj);
                 formatLine = "html";
             } else {
                 result += quoted;
@@ -265,6 +262,8 @@ def getJSInfo(text, stopIdx=-1):
 
         if escaped:
             escaped = False
+        elif char == '\\':
+            escaped = True
         elif char == '\n':
             emptyLineCount += 1
             inSLComment = False
@@ -283,8 +282,6 @@ def getJSInfo(text, stopIdx=-1):
             inMLComment = True
         elif char == '/' and nextChar == '/':
             inSLComment = True
-        elif char == '\\':
-            escaped = True
         elif char == '(':
             parenLevel += 1
         elif char == ')':
@@ -786,6 +783,10 @@ def runJS(content, inTermContext=False, recurseDepth=1, sourceFormatter=SourceFo
         formatLines = sourceFormatter.formatJavascript(formatLines)
     elif formatType == 'html':
         formatLines = sourceFormatter.formatHtml(formatLines)
+
+        # Quote formatLines; if given
+        # as HTML, it isn't quoted already.
+        formatLines = '`' + formatLines.replace('`', '\\`') + '`'
     elif formatType == "undefined":
         formatLines = ""
 

--- a/Resources/bin/jsi
+++ b/Resources/bin/jsi
@@ -494,6 +494,8 @@ try:
             # Invalid base.
             if base.startswith('.'):
                 return
+            elif '..' in base:
+                return
 
             if parentDict is None:
                 parts = base.split('.')
@@ -502,6 +504,13 @@ try:
 
                 for part in parts:
                     baseSoFar.append(part)
+
+                    # If we were given something with
+                    # multiple consecutive '.'s, it's
+                    # invalid.
+                    if part.strip() == '':
+                        return
+
                     if not part in parentDict or not parentDict[part]:
                         partExistsResult = self._runJS("""
                         try {

--- a/Resources_mini/bin/jsi
+++ b/Resources_mini/bin/jsi
@@ -168,10 +168,7 @@ _jsi.stringify_obj = function (obj, recurseDepth, indentation, toplevel) {
             result += quoted;
         } else {
             if (obj.search(/[<][\/][a-zA-Z0-9 \t]+[>]/) >= 0 && recurseDepth >= 0) {
-                for (const line of lines) {
-                    outputLine(line);
-                }
-
+                result += termEscape(obj);
                 formatLine = "html";
             } else {
                 result += quoted;
@@ -265,6 +262,8 @@ def getJSInfo(text, stopIdx=-1):
 
         if escaped:
             escaped = False
+        elif char == '\\':
+            escaped = True
         elif char == '\n':
             emptyLineCount += 1
             inSLComment = False
@@ -283,8 +282,6 @@ def getJSInfo(text, stopIdx=-1):
             inMLComment = True
         elif char == '/' and nextChar == '/':
             inSLComment = True
-        elif char == '\\':
-            escaped = True
         elif char == '(':
             parenLevel += 1
         elif char == ')':
@@ -786,6 +783,10 @@ def runJS(content, inTermContext=False, recurseDepth=1, sourceFormatter=SourceFo
         formatLines = sourceFormatter.formatJavascript(formatLines)
     elif formatType == 'html':
         formatLines = sourceFormatter.formatHtml(formatLines)
+
+        # Quote formatLines; if given
+        # as HTML, it isn't quoted already.
+        formatLines = '`' + formatLines.replace('`', '\\`') + '`'
     elif formatType == "undefined":
         formatLines = ""
 

--- a/Resources_mini/bin/jsi
+++ b/Resources_mini/bin/jsi
@@ -494,6 +494,8 @@ try:
             # Invalid base.
             if base.startswith('.'):
                 return
+            elif '..' in base:
+                return
 
             if parentDict is None:
                 parts = base.split('.')
@@ -502,6 +504,13 @@ try:
 
                 for part in parts:
                     baseSoFar.append(part)
+
+                    # If we were given something with
+                    # multiple consecutive '.'s, it's
+                    # invalid.
+                    if part.strip() == '':
+                        return
+
                     if not part in parentDict or not parentDict[part]:
                         partExistsResult = self._runJS("""
                         try {


### PR DESCRIPTION
## Summary
 * The JavaScript parser used for auto-complete did not recognize escape characters in strings: `"\""` was considered a single string, "\\", followed by the beginning of a new string.
 * Applies HTML syntax highlighting before surrounding outputted HTML in quotes and escaping. This makes printed HTML somewhat easier to read.