### PR TITLE
Fix `jsi` `$` escape bug

### DIFF
--- a/Resources/bin/jsi
+++ b/Resources/bin/jsi
@@ -666,7 +666,7 @@ class Printer:
 def jsQuote(text):
     result = '`'
     for char in text:
-        if char == '`' or char == '\\':
+        if char == '`' or char == '\\' or char == '$':
             result += '\\'
         result += char
     result += '`'

--- a/Resources_mini/bin/jsi
+++ b/Resources_mini/bin/jsi
@@ -666,7 +666,7 @@ class Printer:
 def jsQuote(text):
     result = '`'
     for char in text:
-        if char == '`' or char == '\\':
+        if char == '`' or char == '\\' or char == '$':
             result += '\\'
         result += char
     result += '`'


### PR DESCRIPTION
## Summary
 * `jsi` needed to escape `$`s when quoting JavaScript strings before inserting them into a temporary file.
  * `${foo}` was interpreted as referencing a variable, `foo`, before `jsi` evals code it has been given by the user, leading to incorrect behavior and confusing error messages.