### PR TITLE
Add `perldoc` to list of `less`-like commands (touchscreen interaction)

### DIFF
--- a/gestures.js
+++ b/gestures.js
@@ -97,7 +97,7 @@ function initializeTerminalGestures()
   // Attempts to determine whether `less` or `man` are currently running.
   // Returns true if it thinks less or man is.
   const isLessRunning = () => {
-    return window.commandRunning.search(new RegExp("(^less|^man|.*[|]\\s*less)")) == 0;
+    return window.commandRunning.search(new RegExp("(^less|^man|^perldoc|.*[|]\\s*less)")) == 0;
   };
 
   // Tries to determine whether the current command is vim.

--- a/gestures.js
+++ b/gestures.js
@@ -371,7 +371,7 @@ function initializeTerminalGestures()
       }
 
       // Vertical gestures: Move cursor if in vim/less/man
-      if (window.interactiveCommandRunning && (isVimRunning() || isLessRunning()) || this.maxPtrCount_ == 2) {
+      if (isVimRunning() || isLessRunning() || this.maxPtrCount_ == 2) {
         moveCursor(0, dy);
         term_.scrollEnd();
       } else {


### PR DESCRIPTION
## Summary
 * While #246 had `less` and `man` and `... | less` in the list of `less`-like commands, it didn't have `perldoc`! This PR adds `perldoc` to the list of `less`-like commands.
 * Having to maintain a list of `less` and `vim`-like commands isn't ideal...
   * Using `window.interactiveCommandRunning` won't work for this. Commands like `ipython` and `jsi` should have normal scrolling behavior, but are still marked interactive and `perldoc` isn't marked interactive!