### PR TITLE
`gestures.js`: Bug fixes

### DIFF
--- a/gestures.js
+++ b/gestures.js
@@ -28,7 +28,7 @@ function initializeTerminalGestures()
   // When we start inertial scrolling, scroll this many times faster
   // than how fast we were scrolling with the user's finger/pointer
   // on the screen.
-  const INITIAL_INERTIAL_SCROLL_VEL_MULTIPLIER = 1.4;
+  const INITIAL_INERTIAL_SCROLL_VEL_MULTIPLIER = 1.1;
 
   // Minimum number of characters a cursor must move to trigger a
   //(non-arrow-)key press.
@@ -56,6 +56,8 @@ function initializeTerminalGestures()
     targetElem.addEventListener('pointermove', (evt) =>
       gestures_.gesturePtrMove(evt));
     targetElem.addEventListener('pointerleave', (evt) =>
+      gestures_.gesturePtrUp(evt));
+    targetElem.addEventListener('pointerup', (evt) =>
       gestures_.gesturePtrUp(evt));
     window.term_.document_.body.addEventListener('keydown', (evt) =>
       gestures_.handleKeyEvent(evt));

--- a/gestures.js
+++ b/gestures.js
@@ -63,7 +63,12 @@ function initializeTerminalGestures()
 
     window.term_.document_.body.addEventListener('keydown', (evt) =>
       gestures_.handleKeyEvent(evt));
+
+    // Have listeners inside and outside the terminal iframe:
+    // We want to intercept the wheel event.
     document.body.addEventListener('wheel', (evt) =>
+      gestures_.gestureMouseWheel(evt));
+    window.term_.document_.body.addEventListener('wheel', (evt) =>
       gestures_.gestureMouseWheel(evt));
   }
 
@@ -562,7 +567,7 @@ function initializeTerminalGestures()
 
       // We don't really know how long the gesture took,
       // but let's guess:
-      let dt = 0.25;
+      let dt = 4;
 
       // Scroll events deltaY can be specified in units other than
       // lines. See
@@ -570,10 +575,11 @@ function initializeTerminalGestures()
       if (evt.deltaMode == WheelEvent.DOM_DELTA_PIXEL) {
         dy /= lineHeight;
       } else if (evt.deltaMode == WheelEvent.DOM_DELTA_PAGE) {
-        dy *= term_.screenSize.height;
+        dy *= 0.5 * term_.screenSize.height;
       }
 
-      currentGesture.handleVertical_(evt.deltaY);
+      showDebugMsg("Wheel: " + dy);
+      currentGesture.handleVertical_(dy);
 
       // Estimate a velocity and try to start inertial scrolling.
       const estimatedVy = dy / dt;

--- a/gestures.js
+++ b/gestures.js
@@ -572,7 +572,7 @@ function initializeTerminalGestures()
 
       // We don't really know how long the gesture took,
       // but let's guess:
-      let dt = 4;
+      let dt = 500;
 
       // Scroll events deltaY can be specified in units other than
       // lines. See

--- a/gestures.js
+++ b/gestures.js
@@ -22,6 +22,9 @@ function initializeTerminalGestures()
   // stops.
   const MIN_INERTIAL_SCROLL_CONTINUE_SPEED = 3;
 
+  // Maximum number of lines/second we can scroll
+  const MAX_INERTIAL_SCROLL_SPEED = 2000;
+
   // When we start inertial scrolling, scroll this many times faster
   // than how fast we were scrolling with the user's finger/pointer
   // on the screen.
@@ -98,11 +101,6 @@ function initializeTerminalGestures()
   // Returns true if it thinks less or man is.
   const isLessRunning = () => {
     return window.commandRunning.search(new RegExp("(^less|^man|^perldoc|.*[|]\\s*less)")) == 0;
-  };
-
-  // Tries to determine whether the current command is vim.
-  const isVimRunning = () => {
-    return window.commandRunning.startsWith("vim");
   };
 
   // Commands like less and vim generally use an alternate screen
@@ -452,6 +450,12 @@ function initializeTerminalGestures()
         momentumLoopRunning = false;
       }
     };
+
+    // Some programs stop working if too much input/second
+    // is given.
+    if (Math.abs(vy) > MAX_INERTIAL_SCROLL_SPEED) {
+      vy = Math.sign(vy) * MAX_INERTIAL_SCROLL_SPEED;
+    }
 
     momentum = [vx, vy];
     if (!momentumLoopRunning) {

--- a/gestures.js
+++ b/gestures.js
@@ -556,6 +556,8 @@ function initializeTerminalGestures()
   };
 
   gestures_.gestureMouseWheel = (evt) => {
+    evt.preventDefault();
+
     if (!currentGesture) {
       currentGesture = new Gesture(momentum);
     }
@@ -564,6 +566,9 @@ function initializeTerminalGestures()
 
     try {
       let dy = evt.deltaY;
+
+      // Don't scroll the main window.
+      document.scrollingElement.scrollTop = 0;
 
       // We don't really know how long the gesture took,
       // but let's guess:

--- a/gestures.js
+++ b/gestures.js
@@ -28,7 +28,7 @@ function initializeTerminalGestures()
   // When we start inertial scrolling, scroll this many times faster
   // than how fast we were scrolling with the user's finger/pointer
   // on the screen.
-  const INITIAL_INERTIAL_SCROLL_VEL_MULTIPLIER = 1.1;
+  const INITIAL_INERTIAL_SCROLL_VEL_MULTIPLIER = 1.4;
 
   // Minimum number of characters a cursor must move to trigger a
   //(non-arrow-)key press.
@@ -172,6 +172,11 @@ function initializeTerminalGestures()
         const dx = (evt.pageX - this.lastPosition_[0]) / getCharSize().width;
         const dy = (evt.pageY - this.lastPosition_[1]) / getCharSize().height;
         const dt = (nowTime - this.lastTime_) / 1000;
+
+        // Too small of a time difference -> inaccurate velocities.
+        if (dt < 0.02) {
+          return;
+        }
 
         // Average the current estimated
         // velocity and the last for

--- a/gestures.js
+++ b/gestures.js
@@ -52,7 +52,7 @@ function initializeTerminalGestures()
       gestures_.gesturePtrDown(evt));
     targetElem.addEventListener('pointermove', (evt) =>
       gestures_.gesturePtrMove(evt));
-    targetElem.addEventListener('pointerup', (evt) =>
+    targetElem.addEventListener('pointerleave', (evt) =>
       gestures_.gesturePtrUp(evt));
     window.term_.document_.body.addEventListener('keydown', (evt) =>
       gestures_.handleKeyEvent(evt));
@@ -344,10 +344,14 @@ function initializeTerminalGestures()
         this.isScrollGesture_ = false;
 
         if (dx >= HORIZ_KEYBOARD_KEYPRESS_CHARS) {
+          // Tab key
           term_.io.sendString("\t");
         } else if (dx <= -HORIZ_KEYBOARD_KEYPRESS_CHARS) {
+          // Escape key
           term_.io.sendString("\x1b");
         }
+
+        term_.scrollEnd();
       } else if (!isLessRunning()) {
         // Horizontal gestures: Don't move cursor if in `man'
         moveCursor(dx, 0);
@@ -476,23 +480,29 @@ function initializeTerminalGestures()
     // scrolling.
     momentum = [0, 0];
 
+    if (!currentGesture) {
+      return;
+    }
+
     evt.preventDefault();
 
-    try
-    {
+    try {
       currentGesture.onPointerMove(evt);
-    }
-    catch(e)
-    {
-      alert(e);
+    } catch(e) {
+      if (DEBUG) {
+        alert(e);
+      }
     }
   };
 
   gestures_.gesturePtrUp = (evt) => {
     showDebugMsg(" Up @" + evt.pageX + "," + evt.pageY);
 
-    try
-    {
+    if (!currentGesture) {
+      return;
+    }
+
+    try {
       currentGesture.onPointerUp(evt, startInertialScroll);
 
       if (currentGesture.getPtrDownCount() == 0) {
@@ -500,7 +510,9 @@ function initializeTerminalGestures()
         enableHtermTouchScrolling();
       }
     } catch(e) {
-      alert(e);
+      if (DEBUG) {
+        alert(e);
+      }
     }
   };
 
@@ -509,3 +521,4 @@ function initializeTerminalGestures()
     momentum = [0, 0];
   };
 }
+

--- a/gestures.js
+++ b/gestures.js
@@ -105,6 +105,12 @@ function initializeTerminalGestures()
     return window.commandRunning.startsWith("vim");
   };
 
+  // Commands like less and vim generally use an alternate screen
+  // to display content.
+  const isUsingAlternateScreen = () => {
+    return !term_.isPrimaryScreen();
+  };
+
   const moveCursor = (dx, dy) => {
     for (let i = 0; i <= Math.abs(dx) - 1; i++) {
       term_.io.sendString(dx < 0 ? "\x1b[D" : "\033[C");
@@ -393,7 +399,7 @@ function initializeTerminalGestures()
       }
 
       // Vertical gestures: Move cursor if in vim/less/man
-      if (isVimRunning() || isLessRunning() || this.maxPtrCount_ == 2) {
+      if (isUsingAlternateScreen() || this.maxPtrCount_ == 2) {
         moveCursor(0, dy);
         term_.scrollEnd();
       } else {

--- a/gestures.js
+++ b/gestures.js
@@ -215,6 +215,7 @@ function initializeTerminalGestures()
       this.maxPtrCount_ = 0;
 
       this.origMomentum_ = [carryoverMomentum[0], carryoverMomentum[1]];
+      this.gestureStartTime_ = (new Date()).getTime();
     }
 
     getPtrDownCount() {
@@ -301,11 +302,15 @@ function initializeTerminalGestures()
       const vx = velocity[0];
       const vy = velocity[1];
 
+      const nowTime = (new Date()).getTime();
+      const dt = (nowTime - this.gestureStartTime_) / 1000;
+
+
       if (this.ptrCount_ == 0
           && this.isScrollGesture_
           && Math.abs(vy) >= INERTIAL_SCROLL_MIN_INITIAL_SPEED) {
-        let carryoverX = this.origMomentum_[0];
-        let carryoverY = this.origMomentum_[1];
+        let carryoverX = this.origMomentum_[0] * Math.pow( INERTIAL_SCROLL_DECAY_FACTOR, dt);
+        let carryoverY = this.origMomentum_[1] * Math.pow(INERTIAL_SCROLL_DECAY_FACTOR, dt);
 
         if (Math.sign(carryoverX) != Math.sign(vx)) {
           carryoverX = 0;


### PR DESCRIPTION
## Summary
 * Only `alert()` caught error messages when in debug mode
 * Use `onpointerleave` instead of `onpointerup` to end gestures
     * `onpointerleave` fires when a pointer leaves the window but still isn't down
 * Scroll to the end when the touchscreen generates an escape or tab key press
 * New scroll gestures that trigger inertial scrolling add to the current viewport velocity instead of resetting it.
     * The viewport velocity is still reset if the new scroll gesture is in the opposite direction of the current viewport velocity.
 * `onwheel` is captured and interpreted as a gesture.
     * May fix #186
