### PR TITLE
`man` pages for `config`, `jsc`, and `jsi`

### DIFF
--- a/man/man1/config.1
+++ b/man/man1/config.1
@@ -1,0 +1,84 @@
+.TH CONFIG 1 "14 June 2021"
+.SH NAME
+config \- Configure \fIa-Shell\fP.
+.SH SYNOPSIS
+\fBconfig\fP [ -s font size ]
+  [ -n \fIfont_name\fP? ]
+  [ -b \fIbackground_color\fP ]
+  [ -f \fIforeground_color\fP ]
+  [ -c \fIcursor_color\fP ]
+  [ -g | --global ]
+  [ -p | --permanent ]
+  [ -r | --reset ]
+  [ -d | --default ]
+  [ --show ]
+.SH DESCRIPTION
+\fBconfig\fP can change the settings of the current session,
+the settings of all open sessions,
+or the default settings for new sessions.
+.PP
+For all parameters:
+specify "\fIdefault\fP" to get the default value currently stored,
+"\fIfactory\fP" to get a-Shell factory defaults.
+.PP
+Colors can be defined by names,
+RGB triplets (i.e. red green blue),
+or HexStrings (i.e. '#00FF00').
+.SS Options
+.TP
+\fB-h | --help\fP
+Display usage for \fBconfig\fP.
+.TP
+\fB-s | --size\fP \fISIZE\fP
+Set the font size to \fISIZE\fP `pt'.
+This should be a number.
+Don't include units.
+.TP
+\fB-n | --name\fP \fINAME\fP?
+Set font name to \fINAME\fP or show a font picker dialog.
+.PP
+If \fINAME\fP is not given or is \fIpicker\fP,
+the system font picker dialog is shown.
+.TP
+\fB-b | --background\fP [ \fIFULL_COLOR\fP | \fICOLOR_R COLOR_G COLOR_B\fP ]
+Set background color to \fIFULL_COLOR\fP
+or to \fIrgb(COLOR_R, COLOR_G, COLOR_B)\fP,
+where each component ranges from zero to one.
+.TP
+\fB-f | --foreground\fP [ \fICOLOR\fP | \fICOLOR_R COLOR_G COLOR_B\fP ]
+Set foreground color
+.TP
+\fB-c | --cursor\fP [ \fICOLOR\fP | \fICOLOR_R COLOR_G COLOR_B\fP ]
+set cursor and highlight color.
+.TP
+\fB-g | --global\fP
+Apply settings to all windows currently open
+.TP
+\fB-p | --permanent\fP
+Store settings as default values
+.TP
+\fB-d | --default\fP
+Reset all settings to default values
+.TP
+\fB-r | --reset\fP
+Reset all settings to factory defaults
+.TP
+\fB--show\fP
+Show current settings
+.SS Examples
+.TP
+\fBconfig -p\fP
+Make settings for current window the default for future windows.
+.TP
+\fBconfig -dgp\fP
+Revert all open and future windows to stored default.
+.TP
+\fBconfig -b 0 0 0 -f #00ff00\fP
+Get a green-on-black VT100 look.
+.TP
+\fBconfig -p -b 0 0 0 -f 1 0.5 1\fP
+Set the current session's background
+to black (rgb 0 0 0) with a magenta
+foreground.
+Make this the default configuration.
+

--- a/man/man1/jsc.1
+++ b/man/man1/jsc.1
@@ -1,0 +1,32 @@
+.TH JSC 1 "13 June 2021"
+.SH NAME
+jsc \- Execute JavaScript
+.SH SYNOPSIS
+\fBjsc\fP [ --in-window ] \fIfilename\fP
+.SH DESCRIPTION
+\fBjsc\fP executes JavaScript in a \fIWkWebView\fP,
+either the terminal's WebView or a background WebView.
+.SS Options
+.TP
+\fB--in-window\fP
+Run the contents of the given file in the same
+WkWebView as the terminal GUI.
+If this option is given, the terminal can be
+accessed through the \fIterm_\fP global variable.
+.SS "Using term_"
+The terminal used by \fIa-Shell\fP is accessible via
+the global \fIterm_\fP variable if \fI--in-window\fP is given.
+.PP
+The terminal is inside of an \fIiframe\fP element.
+The \fIiframe\fP's \fIdocument\fP element can be accessed
+via \fIterm_.getDocument()\fP.
+.PP
+If possible, avoid using members of \fIterm_\fP that end with
+an underscore.
+These are private variables whose names are more likely to change
+than variables that do not have such names.
+.SH "SEE ALSO"
+jsi(1)
+.SH BUGS
+The \fIterm_\fP API is unstable!
+Its contents may change when \fIa-Shell\fP updates.

--- a/man/man1/jsi.1
+++ b/man/man1/jsi.1
@@ -1,0 +1,56 @@
+.TH JSI 1 "13 June 2021"
+.SH NAME
+jsi \- An interactive JavaScript shell
+.SH SYNOPSIS
+\fBjsi\fP [ -w ] [ --prompt \fIPROMPT\fP ] [ --no-banner ]
+ [ --no-color ] [ -c \fIJS\fP ]
+ [ --force-inspect ] [ -d \fIINSPECTDEPTH\fP ]
+.SH DESCRIPTION
+\fBjsi\fP is a convenient way to run JavaScript.
+It both accepts input via \fIstdin\fP and the command line.
+.SS Options
+.TP
+\fB-h | --help\fP
+Display a short help message.
+.TP
+\fB-w | --in-window\fP
+Run JavaScript in the same \fIWkWebView\fP as \fIa-Shell\fP's terminal UI.
+.PP
+If this option is given, \fIterm_\fP provides an
+(\fBunstable\fP) terminal API.
+.TP
+\fB--prompt\fP \fIPROMPT\fP
+Specify the prompt string.
+By default, the prompt is \fI% \fP.
+Note that this prompt is only printed if input is from the terminal.
+.TP
+\fB--no-banner\fP
+Don't show a welcome message when entering interactive mode.
+When not entering interactive mode, a welcome message is never shown.
+.TP
+\fB--no-color\fP
+Disable colorized output.
+This also disables autocomplete and autosuggest.
+.TP
+\fB-c\fP \fIJS\fP | \fB--exec\fP \fIJS\fP
+Execute \fIJS\fP instead of entering interactive mode or reading from standard input.
+.TP
+\fB--force-inspect\fP
+Print the details of expressions' resultant objects,
+even if \fBjsi\fP is not in interactive mode.
+.TP
+\fB-d\fP \fIINSPECTDEPTH\fP | \fB--inspect-depth\fP \fIINSPECTDEPTH\fP
+Print \fIINSPECT\fP levels of sub-objects when inspecting an object.
+By default, this is zero.
+.SH "SEE ALSO"
+jsc(1)
+.SH BUGS
+On small screens, colorized input and autocomplete may not function
+properly in \fIa-Shell\fP.
+This is likely a bug in either an underlying library (\fIprompt_toolkit\fP)
+or in \fIa-Shell\fP.
+.PP
+New variables (e.g. \fIlet foo = 3\fP) may not show up in auto-suggest
+until a property of them is referenced.
+In the case of \fIfoo\fP, a user would have to type \fIfoo.something\fP
+to see \fIfoo\fP in the auto-suggest list.


### PR DESCRIPTION
## Summary
 * Adds `man` pages for `config`, `jsi`, and `jsc`
     * `config`'s `man` page is based on its help text.
 * These `man` pages don't always display properly.
     * I've noticed this with other `man` pages, too.
     * See #251
 * Does not update `mandoc.db`