### PR TITLE
`gestures.js`: Use `hterm` scrolling while selecting text.

### DIFF
--- a/gestures.js
+++ b/gestures.js
@@ -154,13 +154,14 @@ function initializeTerminalGestures() {
   };
 
   const moveCursor = (dx, dy) => {
-    let escPrefix = term_.keyboard.applicationCursor ? "\x1bO" : "\x1b[";
+    let escPrefix = gestures_.preferences.altApplicationCursor && term_.keyboard.applicationCursor
+      ? "\x1bO" : "\x1b[";
     for (let i = 0; i <= Math.abs(dx) - 1; i++) {
-      term_.io.sendString(dx < 0 ? escPrefix + "D" : escPrefix + "C");
+      term_.io.onVTKeystroke(dx < 0 ? escPrefix + "D" : escPrefix + "C");
     }
 
     for (let i = 0; i <= Math.abs(dy) - 1; i++) {
-      term_.io.sendString(dy > 0 ? escPrefix + "B" : escPrefix + "A");
+      term_.io.onVTKeystroke(dy > 0 ? escPrefix + "B" : escPrefix + "A");
     }
   };
 

--- a/gestures.js
+++ b/gestures.js
@@ -61,8 +61,7 @@ function initializeTerminalGestures() {
     gestures_.preferences = {
       swipeLeft: {
         // At present, one-finger swipes are always arrow keys
-        2: '\x1b[1~', // Two-finger left swipe: HOME
-        3: '\x1b', // Three-finger left swipe: ESC
+        2: '\x1b', // Two-finger left swipe: ESC
       },
       swipeRight: {
         2: '\t', // Two-finger right swipe: tab
@@ -103,7 +102,7 @@ function initializeTerminalGestures() {
     window.term_.document_.body.addEventListener('wheel', (evt) =>
       gestures_.gestureMouseWheel(evt));
   }
-  gestures_.preferences = gestures_.preferences || {};
+
   let gestureStatus = gestures_.gestureStatus;
 
   // Style the debug output region.
@@ -156,11 +155,11 @@ function initializeTerminalGestures() {
   const moveCursor = (dx, dy) => {
     let escPrefix = term_.keyboard.applicationCursor ? "\x1bO" : "\x1b[";
     for (let i = 0; i <= Math.abs(dx) - 1; i++) {
-      term_.io.onVTKeystroke(dx < 0 ? escPrefix + "D" : escPrefix + "C");
+      term_.io.sendString(dx < 0 ? escPrefix + "D" : escPrefix + "C");
     }
 
     for (let i = 0; i <= Math.abs(dy) - 1; i++) {
-      term_.io.onVTKeystroke(dy > 0 ? escPrefix + "B" : escPrefix + "A");
+      term_.io.sendString(dy > 0 ? escPrefix + "B" : escPrefix + "A");
     }
   };
 
@@ -703,3 +702,4 @@ function initializeTerminalGestures() {
     momentum = [0, 0];
   };
 }
+

--- a/gestures.js
+++ b/gestures.js
@@ -103,7 +103,7 @@ function initializeTerminalGestures() {
     window.term_.document_.body.addEventListener('wheel', (evt) =>
       gestures_.gestureMouseWheel(evt));
   }
-
+  gestures_.preferences = gestures_.preferences || {};
   let gestureStatus = gestures_.gestureStatus;
 
   // Style the debug output region.
@@ -154,8 +154,7 @@ function initializeTerminalGestures() {
   };
 
   const moveCursor = (dx, dy) => {
-    let escPrefix = gestures_.preferences.altApplicationCursor && term_.keyboard.applicationCursor
-      ? "\x1bO" : "\x1b[";
+    let escPrefix = term_.keyboard.applicationCursor ? "\x1bO" : "\x1b[";
     for (let i = 0; i <= Math.abs(dx) - 1; i++) {
       term_.io.onVTKeystroke(dx < 0 ? escPrefix + "D" : escPrefix + "C");
     }

--- a/gestures.js
+++ b/gestures.js
@@ -154,20 +154,13 @@ function initializeTerminalGestures() {
   };
 
   const moveCursor = (dx, dy) => {
+    let escPrefix = term_.keyboard.applicationCursor ? "\x1bO" : "\x1b[";
     for (let i = 0; i <= Math.abs(dx) - 1; i++) {
-      if (term_.keyboard.applicationCursor) {
-		  term_.io.sendString(dx < 0 ? "\x1bOD" : "\033OC");
-	  } else {
-		  term_.io.sendString(dx < 0 ? "\x1b[D" : "\033[C");
-	  }
+      term_.io.sendString(dx < 0 ? escPrefix + "D" : escPrefix + "C");
     }
 
     for (let i = 0; i <= Math.abs(dy) - 1; i++) {
-      if (term_.keyboard.applicationCursor) {
-		  term_.io.sendString(dy > 0 ? "\x1bOB" : "\033OA");
-	  } else {
-		  term_.io.sendString(dy > 0 ? "\x1b[B" : "\033[A");
-	  }
+      term_.io.sendString(dy > 0 ? escPrefix + "B" : escPrefix + "A");
     }
   };
 
@@ -569,19 +562,21 @@ function initializeTerminalGestures() {
       return;
     }
 
-    // If the start of a new gesture (we may have lost
-    // the end of the previous):
-    if (evt.isPrimary) {
-      currentGesture = new Gesture(momentum);
-    }
-
     try {
-      if (!currentGesture) {
+      // If the user has selected something, exit. Let them continue
+      // the selection.
+      const selection = term_.document_.getSelection();
+      if (!selection.isCollapsed) {
+        return;
+      }
+
+      // If the start of a new gesture (we may have lost
+      // the end of the previous):
+      if (evt.isPrimary || !currentGesture) {
         currentGesture = new Gesture(momentum);
       }
 
       momentum = [ 0, 0 ];
-
       currentGesture.onPointerDown(evt);
     } catch(e) {
       if (DEBUG) {
@@ -708,4 +703,3 @@ function initializeTerminalGestures() {
     momentum = [0, 0];
   };
 }
-


### PR DESCRIPTION
## Summary
 * If the user is selecting text, don't use inertial scrolling.
     * The inertial scroll system doesn't always handle events well when there is an expanded selection.
     * There might be a better way to handle this.
 * Makes the default two-finger-left-swipe action `ESC` again.