### PR TITLE
jsi: (Hopefully) fix first-time startup failure

### DIFF
--- a/Resources/bin/jsi
+++ b/Resources/bin/jsi
@@ -892,6 +892,9 @@ if __name__ == "__main__":
                     collectPrints=collectPrints,
                     noinspect=noinspect)
 
+    # The background WkWebView may not exist yet. If so, create it.
+    execJS(";", collectPrints=False, noinspect=True)
+
     out = Printer(args.noColor)
     readIn = InputReader(args.noColor, promptText, execJS)
 

--- a/Resources_mini/bin/jsi
+++ b/Resources_mini/bin/jsi
@@ -892,6 +892,9 @@ if __name__ == "__main__":
                     collectPrints=collectPrints,
                     noinspect=noinspect)
 
+    # The background WkWebView may not exist yet. If so, create it.
+    execJS(";", collectPrints=False, noinspect=True)
+
     out = Printer(args.noColor)
     readIn = InputReader(args.noColor, promptText, execJS)
 


### PR DESCRIPTION
## Summary
 * Occasionally, `jsi` with no flags fails to start, complaining that it was unable to populate its auto-completion list.
   * This _should_ be fixed: 
     * `jsi` now has `jsc` run `;` before attempting to populate its auto-complete list. Previously, `jsi` seemed unable to find the variable, `window`. I suspect that this was related to it being the first time `jsc` was given a file to run...