### PR TITLE
[iOS/iPadOS 15] Add a workaround for QuickType bar

### DIFF
--- a/a-Shell.xcodeproj/project.pbxproj
+++ b/a-Shell.xcodeproj/project.pbxproj
@@ -565,6 +565,7 @@
 		22F75D51265FFFE10056AFD2 /* pythonA-regex._regex.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 22F75D4B265FFF3E0056AFD2 /* pythonA-regex._regex.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		22F75D52266000630056AFD2 /* pythonA-regex._regex.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 22F75D4B265FFF3E0056AFD2 /* pythonA-regex._regex.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		22F75D53266000730056AFD2 /* python3_ios-regex._regex.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 22F75D48265FFF020056AFD2 /* python3_ios-regex._regex.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		891608902713056B00CED1C9 /* KBWebViewBase.m in Sources */ = {isa = PBXBuildFile; fileRef = 8916088E2713056900CED1C9 /* KBWebViewBase.m */; };
 		89483CE425CC48B2008EF012 /* ios_system.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 228E13F225C95F2D0065D825 /* ios_system.xcframework */; };
 /* End PBXBuildFile section */
 
@@ -1456,6 +1457,9 @@
 		22F75D49265FFF2C0056AFD2 /* pythonA-pyfftw.pyfftw.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = "pythonA-pyfftw.pyfftw.xcframework"; path = "cpython/XcFrameworks/pythonA-pyfftw.pyfftw.xcframework"; sourceTree = SOURCE_ROOT; };
 		22F75D4A265FFF340056AFD2 /* pythonA-wordcloud.query_integral_image.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = "pythonA-wordcloud.query_integral_image.xcframework"; path = "cpython/XcFrameworks/pythonA-wordcloud.query_integral_image.xcframework"; sourceTree = SOURCE_ROOT; };
 		22F75D4B265FFF3E0056AFD2 /* pythonA-regex._regex.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = "pythonA-regex._regex.xcframework"; path = "cpython/XcFrameworks/pythonA-regex._regex.xcframework"; sourceTree = SOURCE_ROOT; };
+		8916088D2713056800CED1C9 /* a-Shell-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "a-Shell-Bridging-Header.h"; sourceTree = "<group>"; };
+		8916088E2713056900CED1C9 /* KBWebViewBase.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KBWebViewBase.m; sourceTree = "<group>"; };
+		8916088F2713056A00CED1C9 /* KBWebViewBase.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KBWebViewBase.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1711,12 +1715,15 @@
 				22984EF122C93DBC00069497 /* ContentView.swift */,
 				2208ACC822D24703003985D6 /* WkWebViewExtension.swift */,
 				22BF62282314223D00FEA585 /* WKWebView+KeyCommands.swift */,
+				8916088F2713056A00CED1C9 /* KBWebViewBase.h */,
+				8916088E2713056900CED1C9 /* KBWebViewBase.m */,
 				225177C7231663430084B9C1 /* ListPythonFiles.swift */,
 				22DBA24F233BB0700095C559 /* listTeXFiles.swift */,
 				22984EF322C93DBF00069497 /* Assets.xcassets */,
 				22984EF822C93DBF00069497 /* LaunchScreen.storyboard */,
 				22984EFB22C93DBF00069497 /* Info.plist */,
 				22984EF522C93DBF00069497 /* Preview Content */,
+				8916088D2713056800CED1C9 /* a-Shell-Bridging-Header.h */,
 			);
 			path = "a-Shell";
 			sourceTree = "<group>";
@@ -2323,6 +2330,7 @@
 				2208ACC522D2026E003985D6 /* UIDevice+Name.swift in Sources */,
 				2208ACBF22CCE57E003985D6 /* String+C.swift in Sources */,
 				22984EF222C93DBC00069497 /* ContentView.swift in Sources */,
+				891608902713056B00CED1C9 /* KBWebViewBase.m in Sources */,
 				226013032320403D00AEB059 /* AppDelegate+TeX.swift in Sources */,
 				2208ACC922D24703003985D6 /* WkWebViewExtension.swift in Sources */,
 				22C4A02D22E09D9D00E0FAD2 /* URL+isDirectory.swift in Sources */,
@@ -2676,6 +2684,7 @@
 				STRIP_INSTALLED_PRODUCT = NO;
 				STRIP_STYLE = debugging;
 				SWIFT_INSTALL_OBJC_HEADER = NO;
+				SWIFT_OBJC_BRIDGING_HEADER = "a-Shell/a-Shell-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -2720,6 +2729,7 @@
 				STRIP_INSTALLED_PRODUCT = NO;
 				STRIP_STYLE = debugging;
 				SWIFT_INSTALL_OBJC_HEADER = NO;
+				SWIFT_OBJC_BRIDGING_HEADER = "a-Shell/a-Shell-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};

--- a/a-Shell/ContentView.swift
+++ b/a-Shell/ContentView.swift
@@ -10,8 +10,9 @@ import SwiftUI
 import WebKit
 
 struct Webview : UIViewRepresentable {
+    typealias WebViewType = KBWebViewBase
 
-    let webView: WKWebView
+    let webView: WebViewType
 
     init() {
         let config = WKWebViewConfiguration()
@@ -23,14 +24,14 @@ struct Webview : UIViewRepresentable {
         config.selectionGranularity = .character; // Could be .dynamic
         // let preferences = WKWebpagePreferences()
         // preferences.allowsContentJavaScript = true
-        webView = WKWebView(frame: .zero, configuration: config)
+        webView = .init(frame: .zero, configuration: config)
     }
     
-    func makeUIView(context: Context) -> WKWebView  {
+    func makeUIView(context: Context) -> WebViewType {
         return webView
     }
 
-    func updateUIView(_ uiView: WKWebView, context: Context) {
+    func updateUIView(_ uiView: WebViewType, context: Context) {
         if (uiView.url != nil) { return } // Already loaded the page
         let htermFilePath = Bundle.main.path(forResource: "hterm", ofType: "html")
         uiView.isOpaque = false

--- a/a-Shell/KBWebViewBase.h
+++ b/a-Shell/KBWebViewBase.h
@@ -1,0 +1,41 @@
+//////////////////////////////////////////////////////////////////////////////////
+//
+// B L I N K
+//
+// Copyright (C) 2016-2019 Blink Mobile Shell Project
+//
+// This file is part of Blink.
+//
+// Blink is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Blink is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Blink. If not, see <http://www.gnu.org/licenses/>.
+//
+// In addition, Blink is also subject to certain additional terms under
+// GNU GPL version 3 section 7.
+//
+// You should have received a copy of these additional terms immediately
+// following the terms and conditions of the GNU General Public License
+// which accompanied the Blink Source Code. If not, see
+// <http://www.github.com/blinksh/blink>.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+
+#import <WebKit/WebKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+
+@interface KBWebViewBase : WKWebView
+@end
+
+NS_ASSUME_NONNULL_END

--- a/a-Shell/KBWebViewBase.m
+++ b/a-Shell/KBWebViewBase.m
@@ -1,0 +1,94 @@
+//////////////////////////////////////////////////////////////////////////////////
+//
+// B L I N K
+//
+// Copyright (C) 2016-2019 Blink Mobile Shell Project
+//
+// This file is part of Blink.
+//
+// Blink is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Blink is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Blink. If not, see <http://www.gnu.org/licenses/>.
+//
+// In addition, Blink is also subject to certain additional terms under
+// GNU GPL version 3 section 7.
+//
+// You should have received a copy of these additional terms immediately
+// following the terms and conditions of the GNU General Public License
+// which accompanied the Blink Source Code. If not, see
+// <http://www.github.com/blinksh/blink>.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+
+#import "KBWebViewBase.h"
+#import <objc/runtime.h>
+
+@interface KBWebViewBase (WKScriptMessageHandler) <WKScriptMessageHandler>
+
+- (void)_blink_updateTextInputTraits:(id <UITextInputTraits>)traits;
+
+@end
+
+@interface UIView (Foo)
+
+- (void)_blink_updateTextInputTraits:(id <UITextInputTraits>)traits;
+
+@end
+
+@implementation UIView (Foo)
+
+- (void)_blink_updateTextInputTraits:(id <UITextInputTraits>)traits {
+  UIView * mayBeUs = [[self superview] superview];
+  if ([mayBeUs isKindOfClass:[KBWebViewBase class]]) {
+    KBWebViewBase * base = (KBWebViewBase *)mayBeUs;
+    [base _blink_updateTextInputTraits:traits];
+  }
+}
+
+@end
+
+@implementation KBWebViewBase
+
++ (void)load {
+  NSString * clsName = [@[
+      @"W",//e
+      @"K",//now this is not
+      @"C", //ool.
+      @"ontent", // but it is only way to fix WkWeb
+      @"View", // our radars: FB9628179, https://bugs.webkit.org/show_bug.cgi?id=230360
+  ] componentsJoinedByString:@""];
+
+
+  Class cls = NSClassFromString(clsName);
+  IMP iml = class_getMethodImplementation(cls, NSSelectorFromString(@"_blink_updateTextInputTraits:"));
+
+  class_replaceMethod(cls, NSSelectorFromString(@"_updateTextInputTraits:"), iml, nil);
+
+  SEL selector = sel_getUid("_elementDidFocus:userIsInteracting:blurPreviousNode:activityStateChanges:userObject:");
+  Method method = class_getInstanceMethod(cls, selector);
+  IMP original = method_getImplementation(method);
+  IMP override = imp_implementationWithBlock(^void(id me, void* arg0, BOOL arg1, BOOL arg2, BOOL arg3, id arg4) {
+    ((void (*)(id, SEL, void*, BOOL, BOOL, BOOL, id))original)(me, selector, arg0, TRUE, arg2, arg3, arg4);
+  });
+  method_setImplementation(method, override);
+}
+
+- (void)_blink_updateTextInputTraits:(id <UITextInputTraits>)traits {
+  traits.smartDashesType = UITextSmartDashesTypeNo;
+  traits.smartQuotesType = UITextSmartQuotesTypeNo;
+  traits.autocorrectionType = UITextAutocorrectionTypeNo;
+  traits.autocapitalizationType = UITextAutocapitalizationTypeNone;
+  traits.spellCheckingType = UITextSpellCheckingTypeNo;
+}
+
+@end

--- a/a-Shell/SceneDelegate.swift
+++ b/a-Shell/SceneDelegate.swift
@@ -28,7 +28,7 @@ var stdinString: String = ""
 class SceneDelegate: UIViewController, UIWindowSceneDelegate, WKNavigationDelegate, WKScriptMessageHandler, UIDocumentPickerDelegate, UIPopoverPresentationControllerDelegate, UIFontPickerViewControllerDelegate, UIDocumentInteractionControllerDelegate {
     var window: UIWindow?
     var windowScene: UIWindowScene?
-    var webView: WKWebView?
+    var webView: Webview.WebViewType?
     var wasmWebView: WKWebView? // webView for executing wasm
     var contentView: ContentView?
     var history: [String] = []

--- a/a-Shell/a-Shell-Bridging-Header.h
+++ b/a-Shell/a-Shell-Bridging-Header.h
@@ -1,0 +1,5 @@
+//
+//  Use this file to import your target's public headers that you would like to expose to Swift.
+//
+
+#import "KBWebViewBase.h"


### PR DESCRIPTION
I've confirmed that this workaround from https://github.com/blinksh/blink/commit/0e18174d99a23ea53daa6abfdf84b189a2b36c80 would fix #319 on iOS/iPadOS 15.

Before:

![338F272A-1C0A-4370-99C3-2DBC0E561237](https://user-images.githubusercontent.com/601636/136694746-afc8bc5b-8503-4312-981a-11c5a953aab5.png)

After:

![D1601FD3-2A20-4FE2-B6B0-8D6ED5DDFE43](https://user-images.githubusercontent.com/601636/136694752-770dbb09-4e71-4608-8454-480326c47922.png)
