### PR TITLE
gestures.js: Fix scrolling to end when doing horizontal swipes

### DIFF
--- a/gestures.js
+++ b/gestures.js
@@ -210,9 +210,12 @@ function initializeTerminalGestures() {
     term_.scrollPort_.onTouch = origTouchFn;
   };
 
-  const isLastLineVisible = () => {
+  // Returns true iff the last line is
+  //within a few lines of the cisible region.
+  const isLastLineNearVisible = () => {
+    const errorMargin = 4;
     const scrollPort = term_.getScrollPort();
-    return term_.getRowCount() <= scrollPort.getTopRowIndex() + scrollPort.visibleRowCount;
+    return term_.getRowCount() <= scrollPort.getTopRowIndex() + scrollPort.visibleRowCount + errorMargin;
   };
 
   /// Tracks the velocity of a given
@@ -499,7 +502,7 @@ function initializeTerminalGestures() {
     /// [dx] is in units of characters
     /// and must have magnitude \geq 1
     handleHorizontal_(dx) {
-      if (!isLastLineVisible()) {
+      if (!isLastLineNearVisible()) {
         return;
       }
 
@@ -539,6 +542,7 @@ function initializeTerminalGestures() {
         moveCursor(dx, 0);
       }
 
+      term_.scrollEnd();
       return this;
     }
 

--- a/gestures.js
+++ b/gestures.js
@@ -210,6 +210,11 @@ function initializeTerminalGestures() {
     term_.scrollPort_.onTouch = origTouchFn;
   };
 
+  const isLastLineVisible = () => {
+    const scrollPort = term_.getScrollPort();
+    return term_.getRowCount() <= scrollPort.getTopRowIndex() + scrollPort.visibleRowCount;
+  };
+
   /// Tracks the velocity of a given
   //pointer.
   class VelocityTracker {
@@ -494,6 +499,10 @@ function initializeTerminalGestures() {
     /// [dx] is in units of characters
     /// and must have magnitude \geq 1
     handleHorizontal_(dx) {
+      if (!isLastLineVisible()) {
+        return;
+      }
+
       if (!this.isHorizontal_ && this.isVertical_) {
         // If we're breaking away from a snap...
         this.isVertical_ = false;
@@ -530,7 +539,6 @@ function initializeTerminalGestures() {
         moveCursor(dx, 0);
       }
 
-      term_.scrollEnd();
       return this;
     }
 
@@ -805,4 +813,3 @@ function initializeTerminalGestures() {
     momentum = [0, 0];
   };
 }
-


### PR DESCRIPTION
# Summary
Previously, horizontal touch gestures caused the terminal to scroll the last line into view. This PR only triggers horizontal gestures when the last line is visible (or nearly visible).