### PR TITLE
add a module path to `require.js`

### DIFF
--- a/require.js
+++ b/require.js
@@ -225,7 +225,7 @@
   // NOTE Web-worker will use the origin, since location.href is not available.
   cache = Object.create(null);
   config = config || new Object();
-  config.paths = config.paths || ["./node_modules/"];
+  config.paths = config.paths || ["./node_modules/", "~/Library/local/lib/js_modules"];
   config.resolve = config.resolve || resolve;
   config.root = config.root || location.href;
   require = factory(null);


### PR DESCRIPTION
Trying to add a module path to `require.js`. The path add is `~/Library/local/lib/js_modules` for the default path of `npm` is `/usr/local/lib/npm_modules`.

Reference: Issue#637: https://github.com/holzschu/a-shell/issues/637#issuecomment-1527568078

Something you may concern:
* There dictionary `~/Library/local/lib/js_modules` doesn't exist, which may cause problems. Also you may want to change it to `~/Library/lib/js_modules`.
* For further researches, please build the source and test it.