### PR TITLE
Update createFakeCommands.sh with lg2

### DIFF
--- a/createFakeCommands.sh
+++ b/createFakeCommands.sh
@@ -144,4 +144,4 @@ touch Resources/bin/lualatex
 touch Resources/bin/luatex
 touch Resources/bin/texlua
 touch Resources/bin/texluac
-
+touch Resources/bin/lg2

--- a/createFakeCommands_mini.sh
+++ b/createFakeCommands_mini.sh
@@ -100,4 +100,4 @@ touch Resources_mini/bin/magick-script
 touch Resources_mini/bin/mogrify
 touch Resources_mini/bin/montage
 touch Resources_mini/bin/stream
-
+touch Resources_mini/bin/lg2


### PR DESCRIPTION
Lg2 was not in the fake commands making it impossible to call from inside of vim, python, etc.

I did not recompile the project with this change, and as such did not test it. Since it is such a minor addition though, it should be fine.