### PR TITLE
Update xcfs/Package.resolved

### DIFF
--- a/xcfs/Package.resolved
+++ b/xcfs/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/holzschu/FMake",
         "state": {
           "branch": null,
-          "revision": "db46d80e35764c2367fb23ea01e1876d2c2fa9a6",
-          "version": "0.0.16"
+          "revision": "e9b5d8e3d016ed4a61b9dd77b7365a0bc591c42b",
+          "version": "0.0.19"
         }
       }
     ]


### PR DESCRIPTION
The minimum requirement of FMake is 0.0.19 in [`Package.swift`](https://github.com/holzschu/a-shell/blob/b087c87a4483e5d66dbd0204c8a2e7606c8a4f0a/xcfs/Package.swift#L8), but the resolved version written in [`Package.resolved`](https://github.com/holzschu/a-shell/blob/b087c87a4483e5d66dbd0204c8a2e7606c8a4f0a/xcfs/Package.resolved#L10) is 0.0.16. So `Package.resolved` seems old.

I have updated `Package.resolved` by running `sh downloadFrameworks.sh`. To run it, #866 is required.