### PR TITLE
Fix Ctrl-U behavior

### DIFF
--- a/script.js
+++ b/script.js
@@ -1254,16 +1254,21 @@ function setupHterm() {
 						break;
 					case String.fromCharCode(21):  // Ctrl-U: kill from cursor to beginning of the line
 						disableAutocompleteMenu();
-						// clear entire line and move cursor to beginning of the line
-						io.print('\x1b[2K\x1b[G');
-						io.currentCommand = io.currentCommand
-							.slice(currentCommandCursorPosition);
-						currentCommandCursorPosition = 0;
-						// redraw command line
-						printPrompt();
-						io.print(io.currentCommand);
-						// move cursor back to beginning of the line
-						io.print(`\x1b[${window.promptEnd + 1}G`);
+						if (currentCommandCursorPosition > 0) { // prompt.length
+							// clear entire line and move cursor to beginning of the line
+							io.print('\x1b[2K\x1b[G');
+							// backup remaining characters
+							const remaining = io.currentCommand.slice(currentCommandCursorPosition);
+							// redraw prompt
+							printPrompt();  // This erases the entire io.currentCommand
+							updatePromptPosition();
+							// restore and draw remaining characters
+							io.currentCommand = remaining
+							io.print(io.currentCommand);
+							// move cursor back to beginning of the line
+							io.print(`\x1b[${window.promptEnd + 1}G`);
+							currentCommandCursorPosition = 0;
+						}
 						break;
 					case String.fromCharCode(23):  // Ctrl+W: kill the word behind point
 						disableAutocompleteMenu();

--- a/script.js
+++ b/script.js
@@ -1255,8 +1255,12 @@ function setupHterm() {
 					case String.fromCharCode(21):  // Ctrl-U: kill from cursor to beginning of the line
 						disableAutocompleteMenu();
 						if (currentCommandCursorPosition > 0) { // prompt.length
-							// clear entire line and move cursor to beginning of the line
-							io.print('\x1b[2K\x1b[G');
+							// move cursor back to beginning of the line
+							const scrolledLines = window.promptScroll - this.scrollPort_.getTopRowIndex();
+							const topRowCommand = window.promptLine + scrolledLines;
+							io.print('\x1b[' + (topRowCommand + 1) + ';0H');
+							// clear cursor to end of display
+							io.print('\x1b[0J');
 							// backup remaining characters
 							const remaining = io.currentCommand.slice(currentCommandCursorPosition);
 							// redraw prompt

--- a/script.js
+++ b/script.js
@@ -1263,7 +1263,7 @@ function setupHterm() {
 						printPrompt();
 						io.print(io.currentCommand);
 						// move cursor back to beginning of the line
-						io.print(`\x1b[${window.promptMessage.length + 1}G`);
+						io.print(`\x1b[${window.promptEnd + 1}G`);
 						break;
 					case String.fromCharCode(23):  // Ctrl+W: kill the word behind point
 						disableAutocompleteMenu();


### PR DESCRIPTION
fixes #864

Changes:

1. Fixed an issue where the cursor display position would be incorrect if `PS1` contained invisible characters. (#864) 480284fbd604c282ab96597033c88827565fb549
2. Fixed that Ctrl-U unintentionally deletes characters behind the cursor. 01675da993d964d06886b1ab009eb8c80f70533f
3. Added missing `updatePromptPosition()` after `printPrompt()`. 01675da993d964d06886b1ab009eb8c80f70533f
4. Fixed Ctrl-U behavior when input crossing lines 7c0f0cb221f8fdf8f13f83309912d387569bc77c