### PR TITLE
Add support for Alt-DEL and fix Ctrl-W behavior

### DIFF
--- a/script.js
+++ b/script.js
@@ -1265,13 +1265,23 @@ function setupHterm() {
 						// move cursor back to beginning of the line
 						io.print(`\x1b[${window.promptMessage.length + 1}G`);
 						break;
-					case String.fromCharCode(27) + String.fromCharCode(127):  // Alt-delete key from iOS keyboard
-					case String.fromCharCode(23):  // Ctrl+W: kill the word behind point
+					case String.fromCharCode(27) + String.fromCharCode(127):  // Alt-delete key from iOS keyboard: kill the word behind point
 						disableAutocompleteMenu();
 						deleteBackward();
 						while (currentCommandCursorPosition > 0) {
 							const currentChar = io.currentCommand[currentCommandCursorPosition - 1];
 							if (!isLetter(currentChar)) {
+								break;
+							}
+							deleteBackward();
+						}
+						break;
+					case String.fromCharCode(23):  // Ctrl+W: kill the word behind point, using white space as a word boundary
+						disableAutocompleteMenu();
+						deleteBackward();
+						while (currentCommandCursorPosition > 0) {
+							const currentChar = io.currentCommand[currentCommandCursorPosition - 1];
+							if (currentChar === ' ') {
 								break;
 							}
 							deleteBackward();

--- a/script.js
+++ b/script.js
@@ -1265,6 +1265,7 @@ function setupHterm() {
 						// move cursor back to beginning of the line
 						io.print(`\x1b[${window.promptMessage.length + 1}G`);
 						break;
+					case String.fromCharCode(27) + String.fromCharCode(127):  // Alt-delete key from iOS keyboard
 					case String.fromCharCode(23):  // Ctrl+W: kill the word behind point
 						disableAutocompleteMenu();
 						deleteBackward();


### PR DESCRIPTION
According to https://www.gnu.org/software/bash/manual/bash.html#Commands-For-Killing, Ctrl-W's word boundary is a whitespace. So I fixed it.

Instead, I also added a new keyboard shortcut Alt-DEL, whose word boundary is the same as Alt-left arrow.