### PR TITLE
Add a workaround for a WebKit redraw issue

### DIFF
--- a/script.js
+++ b/script.js
@@ -1916,6 +1916,10 @@ hterm.ScrollPort.prototype.paintIframeContents_ = function() {
       '  display: block;' +
       '  height: var(--hterm-charsize-height);' +
       '  line-height: var(--hterm-charsize-height);' +
+      // Adding `will-change` and `transform` is a workaround for a WebKit redraw issue.
+      // https://github.com/holzschu/a-shell/issues/906
+      '  will-change: transform;' +
+      '  transform: translateZ(0);' +
       '}');
   doc.head.appendChild(style);
 


### PR DESCRIPTION
fixes #906

## Description

I’ve added a workaround to resolve the issue where the `clear` command failed to clear the screen properly. It appears to be caused by a WebKit redrawing bug.

## References

- https://github.com/blinksh/blink/commit/1dd66ee246e61aa192b092a0afe3d43d657a3b28

## How to test this PR

First, please confirm that the issue can be reproduced in the app built from the master branch by following the steps outlined in #906. After that, verify that the same steps do not reproduce the issue in the app built from this PR's branch. (I have already done this.)