### PR TITLE
Always store security-scoped bookmark in pickFolder

### DIFF
--- a/a-Shell/SceneDelegate.swift
+++ b/a-Shell/SceneDelegate.swift
@@ -2046,10 +2046,9 @@ class SceneDelegate: UIViewController, UIWindowSceneDelegate, WKNavigationDelega
         // If you support picking multiple items, make sure you handle them all.
         let newDirectory = urls[0]
         // NSLog("changing directory to: \(newDirectory.path.replacingOccurrences(of: " ", with: "\\ "))")
-        let isReadableWithoutSecurity = FileManager().isReadableFile(atPath: newDirectory.path)
         let isSecuredURL = newDirectory.startAccessingSecurityScopedResource()
         let isReadable = FileManager().isReadableFile(atPath: newDirectory.path)
-        
+
         guard isSecuredURL && isReadable else {
             showAlert("Error", message: "Could not access folder.")
             selectedDirectory = newDirectory.path
@@ -2068,10 +2067,7 @@ class SceneDelegate: UIViewController, UIWindowSceneDelegate, WKNavigationDelega
         // - the bookmark for the URL
         // - a nickname for the bookmark (last component of the URL)
         // The user can edit the nickname later.
-        // the bookmark is only stored once, the nickname is stored each time:
-        if (!isReadableWithoutSecurity) {
-            storeBookmark(fileURL: newDirectory)
-        }
+        storeBookmark(fileURL: newDirectory)
         storeName(fileURL: newDirectory, name: newDirectory.lastPathComponent)
         // Call cd_main instead of ios_system("cd dir") to avoid closing streams.
         if (newDirectory.isDirectory) {


### PR DESCRIPTION
fixes #1026

## Description

When `pickFolder` selected a folder that was already readable (e.g. a subfolder of Documents), it skipped calling `storeBookmark` because `isReadableWithoutSecurity` was true. On the next launch, no bookmark had been persisted, so access to that folder was silently lost.

The fix removes the condition and always calls `storeBookmark`, matching the behaviour for folders that do require a security scope.

## How to test

1. Run `pickFolder` and select any folder (including one inside Documents)
2. Quit a-Shell completely
3. Relaunch
4. Run `showmarks` — the bookmark should still be listed
5. `cd` into it — access should work without re-running `pickFolder`