### PR TITLE
Add Bluetooth background modes to Intents extensions

### DIFF
--- a/a-Shell copy-Info.plist
+++ b/a-Shell copy-Info.plist
@@ -103,6 +103,10 @@
 	<string>a-Shell would like to access to your photo library to upload images</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>a-Shell would like to access to your photo library to upload images</string>
+	<key>NSBluetoothAlwaysUsageDescription</key>
+	<string>a-Shell uses Bluetooth to connect to nearby devices from scripts and commands.</string>
+	<key>NSBluetoothPeripheralUsageDescription</key>
+	<string>a-Shell uses Bluetooth to connect to nearby devices from scripts and commands.</string>
 	<key>NSUserActivityTypes</key>
 	<array>
 		<string>ExecuteCommandIntent</string>

--- a/a-Shell-mini copy-Info.plist
+++ b/a-Shell-mini copy-Info.plist
@@ -127,6 +127,10 @@
 	<string>a-Shell mini would like to access to your photo library to upload images</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>a-Shell mini would like to access to your photo library to upload images</string>
+	<key>NSBluetoothAlwaysUsageDescription</key>
+	<string>a-Shell mini uses Bluetooth to connect to nearby devices from scripts and commands.</string>
+	<key>NSBluetoothPeripheralUsageDescription</key>
+	<string>a-Shell mini uses Bluetooth to connect to nearby devices from scripts and commands.</string>
 	<key>NSUbiquitousContainers</key>
 	<dict>
 		<key>iCloud.AsheKube.app.a-Shell</key>


### PR DESCRIPTION
This adds Bluetooth background mode declarations to the a-Shell and a-Shell mini Intents extensions so Bluetooth central and peripheral use can be enabled from the extension context.

The change is limited to the extension Info.plist files.