### PR TITLE
Add Calendar full access usage descriptions

### DIFF
--- a/a-Shell-Intents/Info.plist
+++ b/a-Shell-Intents/Info.plist
@@ -20,6 +20,8 @@
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSCalendarsFullAccessUsageDescription</key>
+	<string>a-Shell would like to access your calendars to read and write events</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionAttributes</key>

--- a/a-Shell-mini-Info.plist
+++ b/a-Shell-mini-Info.plist
@@ -121,6 +121,8 @@
 	</dict>
 	<key>NSCameraUsageDescription</key>
 	<string>a-Shell mini would like to access your camera</string>
+	<key>NSCalendarsFullAccessUsageDescription</key>
+	<string>a-Shell mini would like to access your calendars to read and write events</string>
 	<key>NSContactsUsageDescription</key>
 	<string>a-Shell mini would like to access your contacts</string>
 	<key>NSPhotoLibraryAddUsageDescription</key>

--- a/a-Shell-mini-Intents/Info.plist
+++ b/a-Shell-mini-Intents/Info.plist
@@ -20,6 +20,8 @@
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSCalendarsFullAccessUsageDescription</key>
+	<string>a-Shell mini would like to access your calendars to read and write events</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionAttributes</key>

--- a/a-Shell/Info.plist
+++ b/a-Shell/Info.plist
@@ -129,6 +129,8 @@
 	</dict>
 	<key>NSCameraUsageDescription</key>
 	<string>a-Shell would like to access your camera</string>
+	<key>NSCalendarsFullAccessUsageDescription</key>
+	<string>a-Shell would like to access your calendars to read and write events</string>
 	<key>NSContactsUsageDescription</key>
 	<string>a-Shell would like to access your contacts</string>
 	<key>NSPhotoLibraryAddUsageDescription</key>


### PR DESCRIPTION
Fixes #1032.

Adds the required `NSCalendarsFullAccessUsageDescription` privacy strings to the app and intent extension bundles so EventKit full calendar access requests can present the iOS permission prompt.