### PR TITLE
Add missing options to the `config(1)` man page

### DIFF
--- a/man/man1/config.1
+++ b/man/man1/config.1
@@ -2,7 +2,7 @@
 .SH NAME
 config \- Configure \fIa-Shell\fP.
 .SH SYNOPSIS
-\fBconfig\fP [ -s font size ]
+\fBconfig\fP [ -s \fIfont_size\fP ]
   [ -n \fIfont_name\fP? ]
   [ -b \fIbackground_color\fP ]
   [ -f \fIforeground_color\fP ]
@@ -41,7 +41,7 @@ Don't include units.
 .TP
 \fB-n | --name\fP \fINAME\fP?
 Set font name to \fINAME\fP or show a font picker dialog.
-.PP
+.sp
 If \fINAME\fP is not given or is \fIpicker\fP,
 the system font picker dialog is shown.
 .TP
@@ -50,11 +50,11 @@ Set background color to \fIFULL_COLOR\fP
 or to \fIrgb(COLOR_R, COLOR_G, COLOR_B)\fP,
 where each component ranges from zero to one.
 .TP
-\fB-f | --foreground\fP [ \fICOLOR\fP | \fICOLOR_R COLOR_G COLOR_B\fP ]
-Set foreground color
+\fB-f | --foreground\fP [ \fIFULL_COLOR\fP | \fICOLOR_R COLOR_G COLOR_B\fP ]
+Set foreground color to \fIFULL_COLOR\fP or to \fIrgb(COLOR_R, COLOR_G, COLOR_B)\fP, where each component ranges from zero to one.
 .TP
-\fB-c | --cursor\fP [ \fICOLOR\fP | \fICOLOR_R COLOR_G COLOR_B\fP ]
-set cursor and highlight color.
+\fB-c | --cursor\fP [ \fIFULL_COLOR\fP | \fICOLOR_R COLOR_G COLOR_B\fP ]
+Set cursor and highlight color to \fIFULL_COLOR\fP or to \fIrgb(COLOR_R, COLOR_G, COLOR_B)\fP, where each component ranges from zero to one.
 .TP
 \fB-k | --cursorShape\fP \fISHAPE\fP
 Set cursor shape. \fISHAPE\fP must be one of bar, beam, block, underline, blinking-bar, blinking-beam, blinking-block, or blinking-underline.
@@ -66,19 +66,19 @@ Possible values for \fILIGATURES\fP: normal, contextual, none...
 Create a configuration file to change the toolbar.
 .TP
 \fB-g | --global\fP
-Apply settings to all windows currently open
+Apply settings to all windows currently open.
 .TP
 \fB-p | --permanent\fP
-Store settings as default values
+Store settings as default values.
 .TP
 \fB-d | --default\fP
-Reset all settings to default values
+Reset all settings to default values.
 .TP
 \fB-r | --reset\fP
-Reset all settings to factory defaults
+Reset all settings to factory defaults.
 .TP
 \fB--show\fP
-Show current settings
+Show current settings.
 .SS Examples
 .TP
 \fBconfig -p\fP

--- a/man/man1/config.1
+++ b/man/man1/config.1
@@ -7,6 +7,9 @@ config \- Configure \fIa-Shell\fP.
   [ -b \fIbackground_color\fP ]
   [ -f \fIforeground_color\fP ]
   [ -c \fIcursor_color\fP ]
+  [ -k \fIcursor_shape\fP ]
+  [ -l \fIligatures\fP ]
+  [ -t | --toolbar ]
   [ -g | --global ]
   [ -p | --permanent ]
   [ -r | --reset ]
@@ -52,6 +55,15 @@ Set foreground color
 .TP
 \fB-c | --cursor\fP [ \fICOLOR\fP | \fICOLOR_R COLOR_G COLOR_B\fP ]
 set cursor and highlight color.
+.TP
+\fB-k | --cursorShape\fP \fISHAPE\fP
+Set cursor shape. \fISHAPE\fP must be one of bar, beam, block, underline, blinking-bar, blinking-beam, blinking-block, or blinking-underline.
+.TP
+\fB-l | --ligatures\fP \fILIGATURES\fP
+Possible values for \fILIGATURES\fP: normal, contextual, none...
+.TP
+\fB-t | --toolbar\fP
+Create a configuration file to change the toolbar.
 .TP
 \fB-g | --global\fP
 Apply settings to all windows currently open


### PR DESCRIPTION
The current `config(1)` man page is old or incomplete. I added missing options: `-k`, `-l`, and `-t`. `config -h` contains them.

I verified that the syntax was correct by running `man man/man1/config.1`.

I also made some other editorial changes.